### PR TITLE
Preserve response status and Inngest protocol headers in InngestHttpApi.layerGroup

### DIFF
--- a/.changeset/chubby-chairs-open.md
+++ b/.changeset/chubby-chairs-open.md
@@ -1,0 +1,5 @@
+---
+"effect-inngest": patch
+---
+
+Preserve the handler response status and Inngest protocol headers when serving through `InngestHttpApi.layerGroup`.

--- a/src/HttpApi.ts
+++ b/src/HttpApi.ts
@@ -7,6 +7,7 @@ import * as HttpApiEndpoint from "effect/unstable/httpapi/HttpApiEndpoint";
 import * as HttpApiGroup from "effect/unstable/httpapi/HttpApiGroup";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { Effect, Layer, Option, Schema } from "effect";
 import { InngestClient } from "./Client.js";
 import type { InngestGroup } from "./Group.js";
@@ -64,16 +65,19 @@ export const layerGroup = <ApiId extends string, Groups extends HttpApiGroup.Any
       onSome: (url) => url.toString(),
     });
 
+  const toResponse = (result: InternalHandler.HandlerResponse<unknown>) =>
+    HttpServerResponse.json(result.body, { status: result.status, headers: result.headers }).pipe(Effect.orDie);
+
   return HttpApiBuilder.group(
     api as unknown as HttpApi.HttpApi<ApiId, InngestApiGroupType>,
     "inngest",
     Effect.fn(function* (handlers) {
       return handlers
         .handle("introspect", ({ request }) =>
-          InternalHandler.handleIntrospection(group, toUrl(request)).pipe(Effect.map((r) => r.body)),
+          InternalHandler.handleIntrospection(group, toUrl(request)).pipe(Effect.flatMap(toResponse)),
         )
         .handle("register", ({ request }) =>
-          InternalHandler.handleRegistration(group, toUrl(request)).pipe(Effect.map((r) => r.body)),
+          InternalHandler.handleRegistration(group, toUrl(request)).pipe(Effect.flatMap(toResponse)),
         )
         .handleRaw("execute", ({ query, request }) =>
           InternalHandler.verifyAndParseRequestBody(request).pipe(
@@ -86,7 +90,7 @@ export const layerGroup = <ApiId extends string, Groups extends HttpApiGroup.Any
                 headers: request.headers,
               }),
             ),
-            Effect.map((r) => r.body),
+            Effect.flatMap(toResponse),
           ),
         );
     }),

--- a/test/integration/httpapigroup.test.ts
+++ b/test/integration/httpapigroup.test.ts
@@ -1,4 +1,4 @@
-import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
+import { FetchHttpClient, HttpClient, HttpClientResponse, HttpRouter, HttpServer } from "effect/unstable/http";
 import { HttpApi, HttpApiBuilder } from "effect/unstable/httpapi";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -13,6 +13,32 @@ const UserCreated = InngestEvent.make(
     userId: Schema.String,
   }),
 );
+
+/**
+ * Create a mock HttpClient layer standing in for the executor's /fn/register.
+ */
+const makeMockHttpClient = (
+  // Match the wire shape from the Inngest executor per spec §4.3.4:
+  // success → `{ ok: true, modified?: boolean }`, failure → `{ error?: string }`.
+  responseBody: { ok?: boolean; modified?: boolean; error?: string } = { ok: true, modified: true },
+  responseStatus = 200,
+) =>
+  Layer.effect(
+    HttpClient.HttpClient,
+    Effect.sync(() =>
+      HttpClient.make((request) =>
+        Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            new Response(JSON.stringify(responseBody), {
+              status: responseStatus,
+              headers: { "Content-Type": "application/json" },
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
 
 describe("TB-012: HttpApiGroup Integration", () => {
   const ProcessUser = InngestFunction.make("process-user", {
@@ -51,6 +77,9 @@ describe("TB-012: HttpApiGroup Integration", () => {
           handler(new Request("http://localhost/inngest", { method: "GET" })),
         );
         expect(getResponse.status).toBe(200);
+        expect(getResponse.headers.get(Protocol.Headers.SDK)).toBe("effect-inngest:v2.0.0");
+        expect(getResponse.headers.get(Protocol.Headers.SDKHandled)).toBe("true");
+        expect(getResponse.headers.get(Protocol.Headers.RequestVersion)).toBe("2");
         const getBody = (yield* Effect.tryPromise(() => getResponse.json())) as {
           function_count: number;
         };
@@ -98,7 +127,12 @@ describe("TB-012: HttpApiGroup Integration", () => {
             }),
           ),
         );
-        expect(postResponse.status).toBe(200);
+        // Checkpointing reports the run through opcodes, so the executor
+        // expects 206 here (spec §4.4.2) rather than 200.
+        expect(postResponse.status).toBe(206);
+        expect(postResponse.headers.get(Protocol.Headers.SDK)).toBe("effect-inngest:v2.0.0");
+        expect(postResponse.headers.get(Protocol.Headers.SDKHandled)).toBe("true");
+        expect(postResponse.headers.get(Protocol.Headers.RequestVersion)).toBe("2");
       } finally {
         yield* Effect.tryPromise(() => dispose());
       }
@@ -145,11 +179,11 @@ describe("TB-012: HttpApiGroup Integration", () => {
     Effect.gen(function* () {
       class MyApi extends HttpApi.make("test-api").add(InngestHttpApi.InngestApiGroup.prefix("/inngest")) {}
 
-      const ClientLive = InngestClient.layer({ id: "test-app", mode: "dev" }).pipe(
-        Layer.provide(FetchHttpClient.layer),
-      );
+      const mockHttpClient = makeMockHttpClient();
 
-      const DependenciesLive = Layer.mergeAll(HandlersLive, ClientLive, FetchHttpClient.layer);
+      const ClientLive = InngestClient.layer({ id: "test-app", mode: "dev" }).pipe(Layer.provide(mockHttpClient));
+
+      const DependenciesLive = Layer.mergeAll(HandlersLive, ClientLive, mockHttpClient);
 
       const InngestLive = InngestHttpApi.layerGroup(MyApi, Group).pipe(Layer.provide(DependenciesLive));
 
@@ -162,8 +196,41 @@ describe("TB-012: HttpApiGroup Integration", () => {
           handler(new Request("http://localhost/inngest", { method: "PUT" })),
         );
         expect(response.status).toBe(200);
+        expect(response.headers.get(Protocol.Headers.SyncKind)).toBe("out_of_band");
         const body = yield* Effect.tryPromise(() => response.json());
-        expect(body).toBeDefined();
+        expect(body).toEqual({ message: "Successfully registered", modified: true });
+      } finally {
+        yield* Effect.tryPromise(() => dispose());
+      }
+    }),
+  );
+
+  it.effect("PUT /inngest returns 500 when registration fails", () =>
+    Effect.gen(function* () {
+      class MyApi extends HttpApi.make("test-api").add(InngestHttpApi.InngestApiGroup.prefix("/inngest")) {}
+
+      const mockHttpClient = makeMockHttpClient({ error: "sync rejected" }, 500);
+
+      const ClientLive = InngestClient.layer({ id: "test-app", mode: "dev" }).pipe(Layer.provide(mockHttpClient));
+
+      const DependenciesLive = Layer.mergeAll(HandlersLive, ClientLive, mockHttpClient);
+
+      const InngestLive = InngestHttpApi.layerGroup(MyApi, Group).pipe(Layer.provide(DependenciesLive));
+
+      const ApiLive = HttpApiBuilder.layer(MyApi).pipe(Layer.provide(InngestLive));
+
+      const { handler, dispose } = HttpRouter.toWebHandler(ApiLive.pipe(Layer.provide(HttpServer.layerServices)));
+
+      try {
+        const response = yield* Effect.tryPromise(() =>
+          handler(new Request("http://localhost/inngest", { method: "PUT" })),
+        );
+        // Spec §4.3.4: a failed sync must not be reported to the caller as 200.
+        expect(response.status).toBe(500);
+        expect(yield* Effect.tryPromise(() => response.json())).toEqual({
+          message: "sync rejected",
+          modified: false,
+        });
       } finally {
         yield* Effect.tryPromise(() => dispose());
       }


### PR DESCRIPTION
### Problem

`InngestHttpApi.layerGroup` returns only `r.body` from all three handlers, discarding the `status` and `headers` that `internal/handler.ts` puts on its `HandlerResponse<T>`:

1. Step opcode responses that must be `206` (spec §4.4.2) are served as `200`, so the executor reads a suspended run as a completed one.
2. Every `x-inngest-*` header is dropped — `x-inngest-sdk`, `x-inngest-sdk-handled`, `x-inngest-req-version`, `x-inngest-sync-kind`, `x-inngest-no-retry`.
3. A failed out-of-band sync returns `{ status: 500, body: { message, modified: false } }` from the handler but reaches the caller as `200 OK` (spec §4.3.4).

`InngestGroup.toWebHandler` is unaffected; only the `HttpApi` adapter is lossy.

### Fix

Forward `{ status, headers, body }` through `HttpServerResponse.json(...)` — the same construct `internal/serve/HttpApp.ts` already uses, so the two serve adapters now agree. This is legitimate in Effect v4: `HttpApiEndpoint.Handler` is typed `Effect<SuccessType<…> | HttpServerResponse, …>` and `HttpApiBuilder` short-circuits on `isHttpServerResponse`, so the response passes through untouched with no cast. Skipping success-schema encoding is wire-identical here because `IntrospectionResponse` and `RegisterResponse` are plain structs with no transformations.

### Tests

- `GET /inngest` asserts the three SDK protocol headers.
- `POST /inngest` asserts `206` plus protocol headers — this changes an existing `toBe(200)` that was asserting the bug; every other 206 assertion in `test/integration/` (durable-sleep, parallel-steps, retry-after-error, regression) already expects this via `toWebHandler`.
- `PUT /inngest` asserts `200`, `x-inngest-sync-kind: out_of_band`, and the exact body; now backed by a mock `/fn/register` client instead of a live `localhost:8288`.
- New `PUT /inngest returns 500 when registration fails`.

Reverting `src/HttpApi.ts` alone fails three of these. `typecheck`, `vp test run` (409 pass), `sg scan src`, `oxlint`, and `vp pack` are all clean; added a `patch` changeset. I hit this integrating effect-inngest behind an `HttpApi` and verified against a real Inngest dev server driving multi-step functions — runs only resume correctly once the `206` survives the adapter.
